### PR TITLE
Add filter group and escape identifiers and literals

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,6 @@ import PackageDescription
 let package = Package(
     name: "Fluent",
     dependencies: [
-        .Package(url: "https://github.com/IBM-Swift/LoggerAPI.git", versions: Version(0,2,0)..<Version(0,3,0)),
+        .Package(url: "https://github.com/IBM-Swift/LoggerAPI.git", versions: Version(0,3,0)..<Version(0,4,0)),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,7 @@ import PackageDescription
 
 let package = Package(
     name: "Fluent",
-    dependencies: [ 
+    dependencies: [
+        .Package(url: "https://github.com/IBM-Swift/LoggerAPI.git", versions: Version(0,2,0)..<Version(0,3,0)),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,5 @@ import PackageDescription
 let package = Package(
     name: "Fluent",
     dependencies: [
-        .Package(url: "https://github.com/IBM-Swift/LoggerAPI.git", versions: Version(0,3,0)..<Version(0,4,0)),
     ]
 )

--- a/Sources/Driver.swift
+++ b/Sources/Driver.swift
@@ -7,4 +7,7 @@ public protocol Driver {
 	func upsert(table table: String, items: [[String: String]])
 	func exists(table table: String, filters: [Filter]) -> Bool
 	func count(table table: String, filters: [Filter]) -> Int
+
+	func escapeIdentifier(identifier: String) -> String
+	func escapeLiteral(literal: String) -> String
 }

--- a/Sources/Filter.swift
+++ b/Sources/Filter.swift
@@ -11,6 +11,7 @@ public class CompareFilter: Filter {
 		self.key = key
 		self.value = value
 		self.comparison = comparison
+		super.init(type: .And)
 	}
 }
 
@@ -27,9 +28,104 @@ public class SubsetFilter: Filter {
 		self.key = key
 		self.superSet = superSet
 		self.comparison = comparison
+		super.init(type: .And)
 	}
 }
 
+public class FilterGroup : Filter {
+
+	public var filters: [Filter] = []
+
+	public func filter(type: GroupType,_ key: String, _ comparison: CompareFilter.Comparison, _ value: String) -> FilterGroup {
+		let filter = CompareFilter(key: key, value: value, comparison: comparison)
+		filter.groupType = type
+		self.filters.append(filter)
+
+		return self
+	}
+
+	public func filter(type: GroupType,_ key: String, in superSet: [String]) -> FilterGroup {
+		let filter = SubsetFilter(key: key, superSet: superSet, comparison: .In)
+		filter.groupType = type
+		self.filters.append(filter)
+
+		return self
+	}
+
+	public func filter(type: GroupType,_ key: String, notIn superSet: [String]) -> FilterGroup {
+		let filter = SubsetFilter(key: key, superSet: superSet, comparison: .NotIn)
+		filter.groupType = type
+		self.filters.append(filter)
+
+		return self
+	}
+
+	//continues
+	public func filter(key: String, _ value: String) -> FilterGroup {
+		return self.filter(.And, key, .Equals, value)
+	}
+
+	public func filter(key: String, _ comparison: CompareFilter.Comparison, _ value: String) -> FilterGroup {
+		return self.filter(.And, key, comparison, value)
+	}
+
+	public func filter(key: String, in superSet: [String]) -> FilterGroup {
+		return self.filter(.And, key, in: superSet)
+	}
+
+	public func filter(key: String, notIn superSet: [String]) -> FilterGroup {
+		return self.filter(.And, key, notIn: superSet)
+	}
+
+	//continues
+	public func and(key: String, _ value: String) -> FilterGroup {
+		return self.filter(key,value)
+	}
+
+	public func or(key: String, _ value: String) -> FilterGroup {
+		return self.filter(.Or, key, .Equals, value)
+	}
+
+	public func and(key: String, _ comparison: CompareFilter.Comparison, _ value: String) -> FilterGroup {
+		return self.filter(key,comparison,value)
+	}
+	public func or(key: String, _ comparison: CompareFilter.Comparison, _ value: String) -> FilterGroup {
+		return self.filter(.Or, key,comparison, value)
+	}
+
+	public func and(key: String, in superSet: [String]) -> FilterGroup {
+		return self.filter(key, in:superSet)
+	}
+	public func or(key: String, in superSet: [String]) -> FilterGroup {
+		return self.filter(.Or, key, in: superSet)
+	}
+
+	public func and(key: String, notIn superSet: [String]) -> FilterGroup {
+		return self.filter(key, notIn: superSet)
+	}
+	public func or(key: String, notIn superSet: [String]) -> FilterGroup {
+		return self.filter(.Or, key, notIn: superSet)
+	}
+
+	public func group (type: FilterGroup.GroupType, filters: (group: FilterGroup)->FilterGroup) -> FilterGroup {
+		let filterGroup = FilterGroup(type:type)
+		self.filters.append(filters(group: filterGroup))
+		return self
+	}
+
+}
+
 public class Filter {
+
+	public enum GroupType {
+		case And, Or
+	}
+
+	public var groupType: GroupType = .And
+	public var isRaw: Bool = false
+
+	init(type: GroupType) {
+		self.groupType = type
+	}
 
 }

--- a/Sources/Filter.swift
+++ b/Sources/Filter.swift
@@ -107,12 +107,15 @@ public class FilterGroup : Filter {
 		return self.filter(.Or, key, notIn: superSet)
 	}
 
-	public func group (type: FilterGroup.GroupType, filters: (group: FilterGroup)->FilterGroup) -> FilterGroup {
+	public func group (type: FilterGroup.GroupType,_ filters: (group: FilterGroup)->FilterGroup) -> FilterGroup {
 		let filterGroup = FilterGroup(type:type)
 		self.filters.append(filters(group: filterGroup))
 		return self
 	}
 
+	public func group (filters: (group: FilterGroup)->FilterGroup) -> FilterGroup {
+		return self.group(.And, filters)
+	}
 }
 
 public class Filter {

--- a/Sources/MemoryDriver.swift
+++ b/Sources/MemoryDriver.swift
@@ -131,6 +131,14 @@ class MemoryDriver: Driver {
 		return count
 	}
 
+	func escapeIdentifier(identifier: String) -> String {
+		return identifier
+	}
+
+	func escapeLiteral(literal: String) -> String {
+		return literal
+	}
+
 	/*func query(query: Query) -> Any? {
 		print("Query")
 

--- a/Sources/PrintDriver.swift
+++ b/Sources/PrintDriver.swift
@@ -107,4 +107,12 @@ class PrintDriver: Driver {
 		}
 	}
 
+	func escapeIdentifier(identifier: String) -> String {
+		return identifier
+	}
+
+	func escapeLiteral(literal: String) -> String {
+		return literal
+	}
+
 }

--- a/Sources/Query.swift
+++ b/Sources/Query.swift
@@ -85,31 +85,79 @@ public class Query<T: Model> {
 	}
 
 	//continues
-	public func filter(key: String, _ value: String) -> Query {
-		let filter = CompareFilter(key: key, value: value, comparison: .Equals)
+	public func filter(type: Filter.GroupType,_ key: String, _ comparison: CompareFilter.Comparison, _ value: String) -> Query {
+		let filter = CompareFilter(key: key, value: value, comparison: comparison)
+		filter.groupType = type
 		self.filters.append(filter)
 
 		return self
+	}
+
+	public func filter(type: Filter.GroupType,_ key: String, in superSet: [String]) -> Query {
+		let filter = SubsetFilter(key: key, superSet: superSet, comparison: .In)
+		filter.groupType = type
+		self.filters.append(filter)
+
+		return self
+	}
+
+	public func filter(type: Filter.GroupType,_ key: String, notIn superSet: [String]) -> Query {
+		let filter = SubsetFilter(key: key, superSet: superSet, comparison: .NotIn)
+		filter.groupType = type
+		self.filters.append(filter)
+
+		return self
+	}
+
+	public func filter(key: String, _ value: String) -> Query {
+		return self.filter(.And, key,.Equals, value)
 	}
 
 	public func filter(key: String, _ comparison: CompareFilter.Comparison, _ value: String) -> Query {
-		let filter = CompareFilter(key: key, value: value, comparison: comparison)
-		self.filters.append(filter)
-
-		return self
+		return self.filter(.And, key,comparison,value)
 	}
 
 	public func filter(key: String, in superSet: [String]) -> Query {
-		let filter = SubsetFilter(key: key, superSet: superSet, comparison: .In)
-		self.filters.append(filter)
-
-		return self
+		return self.filter(.And, key, in:superSet)
 	}
 
 	public func filter(key: String, notIn superSet: [String]) -> Query {
-		let filter = SubsetFilter(key: key, superSet: superSet, comparison: .NotIn)
-		self.filters.append(filter)
+		return self.filter(.And, key, notIn: superSet)
+	}
 
+	//continues
+	public func and(key: String, _ value: String) -> Query {
+		return self.filter(key,value)
+	}
+
+	public func or(key: String, _ value: String) -> Query {
+		return self.filter(.Or, key, .Equals, value)
+	}
+
+	public func and(key: String, _ comparison: CompareFilter.Comparison, _ value: String) -> Query {
+		return self.filter(key,comparison,value)
+	}
+	public func or(key: String, _ comparison: CompareFilter.Comparison, _ value: String) -> Query {
+		return self.filter(.Or, key,comparison, value)
+	}
+
+	public func and(key: String, in superSet: [String]) -> Query {
+		return self.filter(key, in:superSet)
+	}
+	public func or(key: String, in superSet: [String]) -> Query {
+		return self.filter(.Or, key, in: superSet)
+	}
+
+	public func and(key: String, notIn superSet: [String]) -> Query {
+		return self.filter(key, notIn: superSet)
+	}
+	public func or(key: String, notIn superSet: [String]) -> Query {
+		return self.filter(.Or, key, notIn: superSet)
+	}
+
+	public func group (type: FilterGroup.GroupType, filters: (group: FilterGroup)->FilterGroup) -> Query {
+		let filterGroup = FilterGroup(type:type)
+		self.filters.append(filters(group: filterGroup))
 		return self
 	}
 

--- a/Sources/Query.swift
+++ b/Sources/Query.swift
@@ -12,6 +12,14 @@ public class Query<T: Model> {
 		}
 	}
 
+	public var fetchOne: [String:String]? {
+		if let serialized = Database.driver.fetchOne(table: self.table, filters: self.filters) {
+			return serialized
+		} else {
+			return nil
+		}
+	}
+
 	//var results: [Model]
 	public var results: [T] {
 		var models: [T] = []
@@ -23,6 +31,10 @@ public class Query<T: Model> {
 		}
 
 		return models
+	}
+
+	public var fetch: [[String:String]] {
+		return Database.driver.fetch(table: self.table, filters: self.filters)
 	}
 
 	public func update(data: [String: String]) {
@@ -155,10 +167,14 @@ public class Query<T: Model> {
 		return self.filter(.Or, key, notIn: superSet)
 	}
 
-	public func group (type: FilterGroup.GroupType, filters: (group: FilterGroup)->FilterGroup) -> Query {
+	public func group (type: FilterGroup.GroupType,_ filters: (group: FilterGroup)->FilterGroup) -> Query {
 		let filterGroup = FilterGroup(type:type)
 		self.filters.append(filters(group: filterGroup))
 		return self
+	}
+
+	public func group (filters: (group: FilterGroup)->FilterGroup) -> Query {
+		return self.group(.And,filters)
 	}
 
 	public init() {

--- a/Sources/SQL.swift
+++ b/Sources/SQL.swift
@@ -1,3 +1,5 @@
+import LoggerAPI
+
 public class SQL {
 
 	public var table: String
@@ -7,6 +9,8 @@ public class SQL {
 	public var limit: Int?
 	public var data: [String: String]?
 
+	public static var quote: String = "`"
+
 	public enum Operation {
 		case SELECT, DELETE, INSERT, UPDATE
 	}
@@ -14,6 +18,10 @@ public class SQL {
 	public init(operation: Operation, table: String) {
 		self.operation = operation
 		self.table = table
+	}
+
+	private func quoteWord(word: String) -> String {
+		return SQL.quote+word+SQL.quote
 	}
 
 	public var query: String {
@@ -33,7 +41,7 @@ public class SQL {
 // SET column1 = value1, column2 = value2...., columnN = valueN
 // WHERE [condition];
 
-		query.append("`\(self.table)`")
+		query.append(self.quoteWord(self.table))
 
 		if let data = self.data {
 
@@ -43,7 +51,7 @@ public class SQL {
 				var values: [String] = []
 
 				for (key, val) in data {
-					columns.append("`\(key)`")
+					columns.append(self.quoteWord(key))
 
 					if val == "NULL" {
 						values.append("\(val)")
@@ -70,10 +78,11 @@ public class SQL {
 						value = "'\(val)'"
 					}
 
-					updates.append("`\(key)` = \(value)")
+					let quotedKey = self.quoteWord(key)
+					updates.append("\(quotedKey) = \(value)")
 
 				}
-				
+
 				let updatesString = updates.joinWithSeparator(", ")
 				query.append("SET \(updatesString)")
 
@@ -104,8 +113,10 @@ public class SQL {
 						operation = "<"
 					}
 
+					let quotedKey = self.quoteWord(filter.key)
+
 					query.append((index > 0) ? " AND" : "")
-					query.append(" `\(filter.key)` \(operation) '\(filter.value)'")
+					query.append(" \(quotedKey) \(operation) '\(filter.value)'")
 				}
 			}
 		}
@@ -122,6 +133,6 @@ public class SQL {
 	}
 
 	func log(message: Any) {
-		print("[SQL] \(message)")
+		Log.debug("[SQL] \(message)")
 	}
 }

--- a/Sources/SQL.swift
+++ b/Sources/SQL.swift
@@ -9,8 +9,6 @@ public class SQL {
 	public var limit: Int?
 	public var data: [String: String]?
 
-	public static var quote: String = "`"
-
 	public enum Operation {
 		case SELECT, DELETE, INSERT, UPDATE
 	}
@@ -21,7 +19,7 @@ public class SQL {
 	}
 
 	public func quoteWord(word: String) -> String {
-		return SQL.quote+word+SQL.quote
+		return Database.driver.escapeIdentifier(word)
 	}
 
 	public func getData(key: String) -> String {
@@ -30,7 +28,7 @@ public class SQL {
 				if val == "NULL" {
 					return val
 				} else {
-					return "'\(val)'"
+					return Database.driver.escapeLiteral(val)
 				}
 			}
 		}
@@ -108,11 +106,12 @@ public class SQL {
 	}
 
 	public func getFilterValue(filter: CompareFilter) -> String {
-		return "'\(filter.value)'"
+		return Database.driver.escapeLiteral(filter.value)
 	}
 
 	public func getFilterValue(filter: SubsetFilter) -> String {
-		return "'" + filter.superSet.joinWithSeparator("','") + "'"
+		let superSet = filter.superSet.map { Database.driver.escapeLiteral($0) }
+		return superSet.joinWithSeparator(",")
 	}
 
 	func generateFilterQuery(index: Int,_ query: [String] ,_ filters: [Filter]) -> [String] {

--- a/Sources/SQL.swift
+++ b/Sources/SQL.swift
@@ -1,5 +1,3 @@
-import LoggerAPI
-
 public class SQL {
 
 	public var table: String
@@ -201,6 +199,6 @@ public class SQL {
 	}
 
 	func log(message: Any) {
-		Log.debug("[SQL] \(message)")
+		print("[SQL] \(message)")
 	}
 }

--- a/Sources/SQL.swift
+++ b/Sources/SQL.swift
@@ -20,7 +20,7 @@ public class SQL {
 		self.table = table
 	}
 
-	private func quoteWord(word: String) -> String {
+	public func quoteWord(word: String) -> String {
 		return SQL.quote+word+SQL.quote
 	}
 


### PR DESCRIPTION
In this change, each driver has to implement additional two methods (escapeIdentifier/escapeLiteral).
For example, in postgresql case

```swift
    // PostgreSQLDriver.swift
    public func escapeIdentifier(identifier: String) -> String {
        return self.database.escapeIdentifier(identifier)
    }

    public func escapeLiteral(literal: String) -> String {
        return self.database.escapeLiteral(literal)
    }
```

```swift
    // PostgreSQL.swift
    public func escapeIdentifier(identifier: String) -> String {
        if let escaped = String.fromCString(PQescapeIdentifier(connection, identifier, identifier.lengthOfBytesUsingEncoding(NSUTF8StringEncoding))) {
            return escaped
        }
        return ""
    }

    public func escapeLiteral(literal: String) -> String {
        if let escaped = String.fromCString(PQescapeLiteral(connection, literal, literal.lengthOfBytesUsingEncoding(NSUTF8StringEncoding))) {
            return escaped
        }
        return ""
    }
```

I tested it below code

```swift
import Foundation
import Fluent

Database.driver = PostgreSQLDriver(connectionInfo: "hostaddr=192.168.10.210 port=5432 dbname=pcal user=abe password=x5m7B!d sslmode=disable client_encoding=UTF8")

class User : Model {
    var id: String?

    class var table: String {
        return "日本語\\ \"テーブル"
    }
    func serialize() -> [String:String] {
        return ["id":"1","test":"te'st"]
    }

    required init(serialized: [String:String]) {
    }

    static func testQuery() -> User? {
        return Query()
        .filter("日本語\\ \"テーブル","value")
        .filter("fie'ld2",.Equals,"val'ue2")
        .filter("field3", in: ["1","3","5"]) // in
        .filter("field4", notIn: ["2'a'aa","4","6","8","10"])
        .or("field5","value5")
        .group({
            group in

            group.or("field6", "value6")
            .or("field7",.GreaterThanOrEquals,"value7")
            .group(.Or, {
                group in

                group.and("field8","value8")
                .and("field9","value9")

                return group
            })

            return group
        })
        .first
    }
}

User.testQuery()
```

and result is

```sql
SELECT *
FROM "日本語\ ""テーブル"
WHERE "日本語\ ""テーブル" = 'value'
  AND "fie'ld2" = 'val''ue2'
  AND "field3" IN ('1',
                    '3',
                    '5')
  AND "field4" NOT IN ('2''a''aa',
                             '4',
                             '6',
                             '8',
                             '10')
  OR "field5" = 'value5'
  AND ("field6" = 'value6'
       OR "field7" >= 'value7'
       OR ("field8" = 'value8'
           AND "field9" = 'value9')) LIMIT 1;
```