### PR TITLE
Split the ActiveRecord-style Model from the bare Entity

### DIFF
--- a/Sources/Fluent/Model.swift
+++ b/Sources/Fluent/Model.swift
@@ -1,11 +1,13 @@
 
-public protocol Model {
+public protocol Entity {
     static var entity: String { get }
     var id: String? { get }
     
     func serialize() -> [String: Value?]
     init(serialized: [String: Value])
 }
+
+public protocol Model: Entity {}
 
 extension Model {    
     public func save() throws {


### PR DESCRIPTION
This way, one can choose to use bare entities with an EntityMapper
class (like Doctrine does it) instead of the ActiveRecord style models
that Fluent provides.