### PR TITLE
Fix SQL UPDATE syntax

### DIFF
--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -82,8 +82,9 @@ public class GeneralSQLSerializer: SQLSerializer {
 
             statement += "UPDATE"
             statement += sql(table)
+            statement += "SET"
 
-            let (dataClause, dataValues) = sql(data)
+            let (dataClause, dataValues) = sql(update: data)
             statement += dataClause
             values += dataValues
 
@@ -244,6 +245,17 @@ public class GeneralSQLSerializer: SQLSerializer {
             sql(clause),
             values
         )
+    }
+
+    public func sql(update data: [String: Value]) -> (String, [Value]) {
+        return (
+            data.map(sql).joined(separator: ", "),
+            Array(data.values)
+        )
+    }
+
+    public func sql(key: String, value: Value) -> String {
+        return sql(key) + " = " + sql(value)
     }
 
     public func sql(_ strings: [String]) -> String {

--- a/Tests/Fluent/SQLSerializerTests.swift
+++ b/Tests/Fluent/SQLSerializerTests.swift
@@ -41,7 +41,7 @@ class SQLSerializerTests: XCTestCase {
         let update = SQL.update(table: "friends", filters: [filter], data: ["not it": true])
         let (statement, values) = serialize(update)
 
-        XCTAssertEqual(statement, "UPDATE `friends` (`not it`) VALUES (?) WHERE `name` = ?")
+        XCTAssertEqual(statement, "UPDATE `friends` SET `not it` = ? WHERE `name` = ?")
         XCTAssertEqual(values.first?.bool, true)
         XCTAssertEqual(values.last?.string, "duck")
         XCTAssertEqual(values.count, 2)


### PR DESCRIPTION
This changes the data clause of the SQL UPDATE syntax from
```SQL
UPDATE `table` (`row1`, `row2`) VALUES (?, ?)
```
to
```SQL
UPDATE `table` SET `row1` = ?, `row2` = ?
```
The previous syntax was not working for me and I could not find a reference to it being a valid SQL syntax.